### PR TITLE
Fix UnicodeDecodeError on old ZWiki instances

### DIFF
--- a/ZWikiPage.py
+++ b/ZWikiPage.py
@@ -206,7 +206,10 @@ class ZWikiPage(
 
     def preRendered(self):
         # cope with non-existing or None attribute on old instances - needed ?
-        return getattr(self,'_prerendered','') or ''
+        try:
+            return unicode(getattr(self,'_prerendered','') or '')
+        except UnicodeError:
+            return ''
 
     ######################################################################
     # initialization


### PR DESCRIPTION
A long time ago ZWiki dealt with byte strings.  Old ZWiki instances may still
have prerendered pages that are stored as byte strings rather than the unicode
we now expect.

Instead of trying to guess the charset let's just re-render.

Fixes the following error I saw on an old ZWiki:

```
Module ZPublisher.Publish, line 138, in publish
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 48, in call_object
Module Products.ZWiki.ZWikiPage, line 245, in __call__
  else: return self.render(client,REQUEST,RESPONSE,**kw)
Module Products.ZWiki.ZWikiPage, line 257, in render
  r = self.pageType().render(self, REQUEST, RESPONSE, **kw)
Module Products.ZWiki.plugins.pagetypes.stx, line 97, in render
  t = page.renderMidsectionIn(t,**kw)
Module Products.ZWiki.ZWikiPage, line 356, in renderMidsectionIn
  return doc + self.renderMidsection(**kw) + discussion
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc4 in position 39: ordinal not in range(128)
```
